### PR TITLE
Fixed bugs and added sample config for lighttpd

### DIFF
--- a/SAMPLE.lighttpd
+++ b/SAMPLE.lighttpd
@@ -1,0 +1,16 @@
+################################ EXPIRE HEADERS ################################
+$HTTP["url"] =~ "\.(ico|jpe?g|png|gif|swf|gz|ttf)$" {
+        expire.url = ( "" => "access plus 1 years" )
+}
+
+############################## UNSET ETAG HEADER ###############################
+etag.use-inode = "disable"
+etag.use-mtime = "disable"
+etag.use-size = "disable"
+static-file.etags = "disable"
+
+################################# REWRITE URLS #################################
+# Rewrite all non-file requests to /cache
+url.rewrite-repeat-if-not-file = ( "^/(.*)$" => "/cache/$1" )
+# If file is not found from /cache/, rewrite request to index.php
+url.rewrite-if-not-file = ( "^/cache/(|(http|https)\/)([0-9]+x[0-9]+|[a-z]+[0-9]+|original)\/(.*)$" => "index.php?scheme=$2&path=$4&format=$3" )

--- a/config/SAMPLE.config.inc.php
+++ b/config/SAMPLE.config.inc.php
@@ -10,3 +10,4 @@
  */
 
 define('CACHE_FOLDER', dirname(__FILE__).'/../cache');
+define('EXPIRE_DAYS', 365);

--- a/src/Image/GDImage.php
+++ b/src/Image/GDImage.php
@@ -78,6 +78,9 @@ class GDImage extends AbstractImage
 		} else {
 			$oResized = ImageCreate($iWidth,$iHeight);
 		}
+		//Save alpha
+		imagealphablending($oResized, false);
+		imagesavealpha($oResized, true);
 		//Compute resize
 		imagecopyresampled( $oResized, $this->resource, 0, 0, 0, 0, $iWidth, $iHeight, $this->width, $this->height );
 
@@ -104,6 +107,9 @@ class GDImage extends AbstractImage
 		} else {
 			$oResized = ImageCreate($iWidth,$iHeight);
 		}
+		//Save alpha
+		imagealphablending($oResized, false);
+		imagesavealpha($oResized, true);
 		//Compute resize
 		imagecopyresampled( $oResized, $this->resource, 0, 0, $iX, $iY, $iWidth, $iHeight, $iWidth, $iHeight );
 

--- a/src/Image/ImageFactory.php
+++ b/src/Image/ImageFactory.php
@@ -25,7 +25,10 @@ final class ImageFactory
 	 */
 	public static function build($path) {
 		//If image magick use it
-		if( extension_loaded('imagick') ) {
+		//..but only for non-PNG images as certain PNG images
+		//cause ImageMagick to segfault
+		$useImagick = strtolower(substr($path, strrpos($path, '.') + 1 )) !== 'png';
+		if( $useImagick && extension_loaded('imagick') ) {
 			require_once dirname(__FILE__).'/ImagickImage.php';
 			$oResized = new ImagickImage($path);
 		//Else just use GD

--- a/src/Image/ImagickImage.php
+++ b/src/Image/ImagickImage.php
@@ -40,6 +40,8 @@ class ImagickImage extends AbstractImage
 	 */
 	protected function buildResource( $sPath ) {
 		$this->resource = new Imagick($sPath);
+		//Limit Imagick to single thread -- https://bugs.php.net/bug.php?id=61122
+		$this->resource->setResourceLimit(6, 1);
 		$this->width = $this->resource->getImageWidth();
 		$this->height = $this->resource->getImageHeight();
 	}
@@ -49,7 +51,7 @@ class ImagickImage extends AbstractImage
 	 */
 	protected function destroyResource() {
 		if( $this->resource instanceof Imagick ) {
-			$this->resource->destroy();
+			$this->resource->clear();
 		}
 	}
 


### PR DESCRIPTION
Fixed: added missing / to cache folder path
Fixed: cleanup ':' character from path as well
Fixed: replace spaces with %20 in URL before curl request
Fixed: close curl handle and unset ImageFactory object after request
Fixed: save alpha channel when using GD and handing transparent PNGs
Fixed: limit Imagick to single thread to avoid segfault on request end
Changed: use ImageMagick only for non-png images due to imagick
extension segfaulting on pngs
Changed: use clear() method for destroying Imagick instance instead of
detroy()
Changed: define expiry headers based on EXPIRE_DAYS
Changed: don't set Pragma: public header
Added: lighttpd sample config

Also added some (unsafe) curl options to handle unknown SSL keys. This makes the downloads vulnerable to MITM attacks, but in this use-case the gains outweigh the risks.
